### PR TITLE
Test multiple versions of gradle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+
+    strategy:
+      matrix:
+        gradle-version: [ '7.5.1', '7.6.2', '8.0.1', '8.2.1' ]
+
     steps:
       - uses: actions/checkout@v3
 
@@ -14,6 +19,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         id: gradle
         with:
+          gradle-version: ${{ matrix.gradle-version }}
           arguments: check buildHealth --scan --continue
 
       - name: Verify build health


### PR DESCRIPTION
Use strategy matrix to test out with different versions of gradle.

Documentation:
[Specifying specific gradle version to build-action
](https://github.com/gradle/gradle-build-action#use-a-specific-gradle-version)
[Using a matrix strategy
](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#using-a-matrix-strategy)

Fixes: https://github.com/Nava2/gradle-plugin-better-testing/issues/4