### PR TITLE
[Refactor] Simplify configuration reading as individual merged values

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,18 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <JavaCodeStyleSettings>
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="2147483647" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="2147483647" />
+      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+        <value />
+      </option>
+    </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value />
+      </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="51" />
+      <option name="IMPORT_NESTED_CLASSES" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="kotlin">

--- a/gradle-plugin-better-testing-junit5/src/main/kotlin/net/navatwo/gradle/testkit/junit5/ConfigurationProvider.kt
+++ b/gradle-plugin-better-testing-junit5/src/main/kotlin/net/navatwo/gradle/testkit/junit5/ConfigurationProvider.kt
@@ -1,0 +1,17 @@
+package net.navatwo.gradle.testkit.junit5
+
+import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration.Companion.DEFAULT
+import org.junit.jupiter.api.extension.ExtensionContext
+
+internal object ConfigurationProvider {
+  fun getConfigForContext(context: ExtensionContext): GradleTestKitConfiguration {
+    val testKitConfigurations = context.collectAnnotations(GradleTestKitConfiguration::class)
+    val implicitConfigurations = listOf(
+      SystemPropertyOverrides.systemConfiguration(),
+      SystemPropertyOverrides.internalConfiguration(),
+      DEFAULT,
+    )
+    return (testKitConfigurations + implicitConfigurations)
+      .reduce { acc, config -> GradleTestKitConfiguration.merge(acc, config) }
+  }
+}

--- a/gradle-plugin-better-testing-junit5/src/main/kotlin/net/navatwo/gradle/testkit/junit5/ExtensionContextExtensions.kt
+++ b/gradle-plugin-better-testing-junit5/src/main/kotlin/net/navatwo/gradle/testkit/junit5/ExtensionContextExtensions.kt
@@ -1,0 +1,27 @@
+package net.navatwo.gradle.testkit.junit5
+
+import org.junit.jupiter.api.extension.ExtensionContext
+import java.util.Optional
+import kotlin.reflect.KClass
+
+internal fun <A : Annotation> ExtensionContext.collectAnnotations(annotationClass: KClass<A>): List<A> {
+  return sequence {
+    var currentContext: ExtensionContext? = this@collectAnnotations
+    while (currentContext != null) {
+      val methodAnn = currentContext.testMethod.flatMap { m ->
+        Optional.ofNullable(m.getAnnotation(annotationClass.java))
+      }
+
+      yield(methodAnn)
+
+      val classAnn = currentContext.testClass.flatMap { c ->
+        Optional.ofNullable(c.getAnnotation(annotationClass.java))
+      }
+      yield(classAnn)
+
+      currentContext = currentContext.parent.orElse(null)
+    }
+  }
+    .mapNotNull { it.orElse(null) }
+    .toList()
+}

--- a/gradle-plugin-better-testing-junit5/src/main/kotlin/net/navatwo/gradle/testkit/junit5/SystemPropertyOverrides.kt
+++ b/gradle-plugin-better-testing-junit5/src/main/kotlin/net/navatwo/gradle/testkit/junit5/SystemPropertyOverrides.kt
@@ -1,0 +1,48 @@
+package net.navatwo.gradle.testkit.junit5
+
+/**
+ * Defines system property overrides.
+ */
+internal object SystemPropertyOverrides {
+  private const val SYSTEM_PREFIX = "net.navatwo.gradle.testkit.junit5"
+
+  /**
+   * @see GradleTestKitConfiguration.projectsRoot
+   */
+  internal const val SYSTEM_PROJECT_ROOTS = "$SYSTEM_PREFIX.projectRoots"
+
+  /**
+   * @see GradleTestKitConfiguration.withPluginClasspath
+   */
+  private const val SYSTEM_IS_INTERNAL = "$SYSTEM_PREFIX.internal"
+
+  /**
+   * @see GradleTestKitConfiguration.withPluginClasspath
+   */
+  internal const val SYSTEM_WITH_PLUGIN_CLASSPATH = "$SYSTEM_PREFIX.withPluginClasspath"
+
+  /**
+   * @see GradleTestKitConfiguration.gradleVersion
+   */
+  internal const val SYSTEM_GRADLE_VERSION = "$SYSTEM_PREFIX.gradleVersion"
+
+  fun systemConfiguration(): GradleTestKitConfiguration = GradleTestKitConfiguration(
+    projectsRoot = System.getProperty(SYSTEM_PROJECT_ROOTS, GradleTestKitConfiguration.NO_OVERRIDE_VERSION),
+    withPluginClasspath = System.getProperty(
+      SYSTEM_WITH_PLUGIN_CLASSPATH,
+      GradleTestKitConfiguration.DEFAULT_WITH_PLUGIN_CLASSPATH.toString(),
+    ).toBoolean(),
+    gradleVersion = System.getProperty(SYSTEM_GRADLE_VERSION, GradleTestKitConfiguration.NO_OVERRIDE_VERSION),
+  )
+
+  internal fun internalConfiguration(): GradleTestKitConfiguration = GradleTestKitConfiguration(
+    withPluginClasspath = run {
+      val isInternalTest = System.getProperty(
+        SYSTEM_IS_INTERNAL,
+        GradleTestKitConfiguration.DEFAULT_WITH_PLUGIN_CLASSPATH.toString()
+      ).toBoolean()
+      val ifInternalDoNotUseClasspath = !isInternalTest
+      ifInternalDoNotUseClasspath
+    },
+  )
+}


### PR DESCRIPTION
We break apart the reading of different configuration sources to individual values of `GradleTestKitConfiguration` instances. This makes it easier to make changes in the future.