### PR TITLE
[TestKit] Add support for system property testkit directory override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,19 @@ jobs:
       - name: Verify gradle wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Cache TestKits
-        id: cache-testkits
-        uses: actions/cache@v3
-        with:
-          path: '**/build/test-kit'
-          key: gradle-${{ matrix.gradle-version }}-testkits
-
       - name: Run CI checks
         uses: gradle/gradle-build-action@v2
         id: gradle
         with:
           gradle-version: ${{ matrix.gradle-version }}
           arguments: check buildHealth --scan --continue
+
+      - name: Cache TestKit
+        id: cache-testkit
+        uses: actions/cache@v3
+        with:
+          path: '**/.gradle/testKit'
+          key: gradle-${{ matrix.gradle-version }}-testkit
 
       - name: Verify build health
         run: |

--- a/build-logic/src/main/kotlin/better-testing.kotlin.gradle.kts
+++ b/build-logic/src/main/kotlin/better-testing.kotlin.gradle.kts
@@ -121,3 +121,14 @@ tasks.withType<Jar> {
     )
   }
 }
+
+val testKitDirectory: Directory = rootProject.layout.projectDirectory.dir(".gradle/testKit")
+
+tasks.clean {
+  delete(testKitDirectory)
+}
+
+tasks.test {
+  systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")
+  systemProperty("net.navatwo.gradle.testkit.junit5.testKitDirectory", testKitDirectory.asFile.toString())
+}

--- a/gradle-plugin-better-testing-junit5/build.gradle.kts
+++ b/gradle-plugin-better-testing-junit5/build.gradle.kts
@@ -19,18 +19,6 @@ dependencies {
 }
 
 tasks.test {
-  jvmArgs(
-    "-Djunit.jupiter.extensions.autodetection.enabled=true",
-
-    // We need to avoid calling `withPluginClasspath()` when we write our own tests.
-    "-Dnet.navatwo.gradle.testkit.junit5.internal=true",
-  )
-
-  val gradleVersionOverride = providers.gradleProperty("net.navatwo.gradle.testkit.junit5.testing.gradleVersion")
-    .map { version ->
-      "-Dnet.navatwo.gradle.testkit.junit5.gradleVersion=$version"
-    }
-  if (gradleVersionOverride.isPresent) {
-    jvmArgs(gradleVersionOverride.get())
-  }
+  // We need to avoid calling `withPluginClasspath()` when we write our own tests.
+  systemProperty("net.navatwo.gradle.testkit.junit5.internal", true)
 }

--- a/gradle-plugin-better-testing-junit5/src/main/kotlin/net/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration.kt
+++ b/gradle-plugin-better-testing-junit5/src/main/kotlin/net/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration.kt
@@ -25,6 +25,7 @@ annotation class GradleTestKitConfiguration(
    * Annotates the directory used for [org.gradle.testkit.runner.GradleRunner.withTestKitDir].
    *
    * Default value: [DEFAULT_TESTKIT_DIRECTORY]
+   * System Override: `net.navatwo.gradle.testkit.junit5.testKitDirectory` - [SystemPropertyOverrides.SYSTEM_TEST_KIT_DIRECTORY]
    */
   val testKitDirectory: String = NO_OVERRIDE_VERSION,
 

--- a/gradle-plugin-better-testing-junit5/src/main/kotlin/net/navatwo/gradle/testkit/junit5/GradleTestKitProjectExtension.kt
+++ b/gradle-plugin-better-testing-junit5/src/main/kotlin/net/navatwo/gradle/testkit/junit5/GradleTestKitProjectExtension.kt
@@ -29,7 +29,7 @@ import kotlin.reflect.jvm.kotlinFunction
  *
  * This provides sensible defaults for performance and ease of use. All defaults are overridden via annotations. To use
  * this extension, enable extensions in your project either via:
- * 1. Add `-Djunit.jupiter.extensions.autodetection.enabled=true` to your Test JVM arguments
+ * 1. Add `systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")` to your Test JVM arguments
  * 2. Add `@ExtendsWith(GradleTestKitProjectExtension::class)` to your test class
  *
  * This extension assumes projects are defined in a "projects" directory (e.g. `src/test/projects`). This can be

--- a/gradle-plugin-better-testing-junit5/src/main/kotlin/net/navatwo/gradle/testkit/junit5/SystemPropertyOverrides.kt
+++ b/gradle-plugin-better-testing-junit5/src/main/kotlin/net/navatwo/gradle/testkit/junit5/SystemPropertyOverrides.kt
@@ -12,6 +12,11 @@ internal object SystemPropertyOverrides {
   internal const val SYSTEM_PROJECT_ROOTS = "$SYSTEM_PREFIX.projectRoots"
 
   /**
+   * @see GradleTestKitConfiguration.testKitDirectory
+   */
+  internal const val SYSTEM_TEST_KIT_DIRECTORY = "$SYSTEM_PREFIX.testKitDirectory"
+
+  /**
    * @see GradleTestKitConfiguration.withPluginClasspath
    */
   private const val SYSTEM_IS_INTERNAL = "$SYSTEM_PREFIX.internal"
@@ -28,6 +33,7 @@ internal object SystemPropertyOverrides {
 
   fun systemConfiguration(): GradleTestKitConfiguration = GradleTestKitConfiguration(
     projectsRoot = System.getProperty(SYSTEM_PROJECT_ROOTS, GradleTestKitConfiguration.NO_OVERRIDE_VERSION),
+    testKitDirectory = System.getProperty(SYSTEM_TEST_KIT_DIRECTORY, GradleTestKitConfiguration.NO_OVERRIDE_VERSION),
     withPluginClasspath = System.getProperty(
       SYSTEM_WITH_PLUGIN_CLASSPATH,
       GradleTestKitConfiguration.DEFAULT_WITH_PLUGIN_CLASSPATH.toString(),


### PR DESCRIPTION
Add support for overriding the gradle test kit via a system property. This is very beneficial when using CI to keep consistency.

This updates the project itself to share the test kit among all projects.