### PR TITLE
#27 - Fix plugin classpath behaviour

### DIFF
--- a/build-logic/src/main/kotlin/better-testing.versioning.gradle.kts
+++ b/build-logic/src/main/kotlin/better-testing.versioning.gradle.kts
@@ -1,6 +1,6 @@
 
 group = "net.navatwo.gradle"
-version = "0.0.4-SNAPSHOT"
+version = "0.0.5-SNAPSHOT"
 
 val isRelease = providers.environmentVariable("RELEASE")
   .map { it.isNotBlank() }

--- a/gradle-plugin-better-testing-assertj-asserts/src/test/kotlin/net/navatwo/gradle/testkit/assertj/BuildResultAssertsTest.kt
+++ b/gradle-plugin-better-testing-assertj-asserts/src/test/kotlin/net/navatwo/gradle/testkit/assertj/BuildResultAssertsTest.kt
@@ -2,6 +2,7 @@ package net.navatwo.gradle.testkit.assertj
 
 import net.navatwo.gradle.testkit.junit5.GradleProject
 import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration
+import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration.ClasspathMode.NO_PROJECT_CLASSPATH
 import net.navatwo.gradle.testkit.junit5.GradleTestKitProjectExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(GradleTestKitProjectExtension::class)
 @GradleTestKitConfiguration(
-  withPluginClasspath = false,
+  classpathMode = NO_PROJECT_CLASSPATH,
 )
 class BuildResultAssertsTest {
   @Test

--- a/gradle-plugin-better-testing-junit5/api/gradle-plugin-better-testing-junit5.api
+++ b/gradle-plugin-better-testing-junit5/api/gradle-plugin-better-testing-junit5.api
@@ -11,10 +11,10 @@ public abstract interface annotation class net/navatwo/gradle/testkit/junit5/Gra
 public abstract interface annotation class net/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration : java/lang/annotation/Annotation {
 	public static final field Companion Lnet/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$Companion;
 	public abstract fun buildDirectoryMode ()Lnet/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$BuildDirectoryMode;
+	public abstract fun classpathMode ()Lnet/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$ClasspathMode;
 	public abstract fun gradleVersion ()Ljava/lang/String;
 	public abstract fun projectsRoot ()Ljava/lang/String;
 	public abstract fun testKitDirectory ()Ljava/lang/String;
-	public abstract fun withPluginClasspath ()Z
 }
 
 public final class net/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$BuildDirectoryMode : java/lang/Enum {
@@ -26,6 +26,17 @@ public final class net/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lnet/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$BuildDirectoryMode;
 	public static fun values ()[Lnet/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$BuildDirectoryMode;
+}
+
+public final class net/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$ClasspathMode : java/lang/Enum {
+	public static final field NO_PROJECT_CLASSPATH Lnet/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$ClasspathMode;
+	public static final field UNSET Lnet/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$ClasspathMode;
+	public static final field WITH_PROJECT_CLASSPATH Lnet/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$ClasspathMode;
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public abstract fun setupRunner (Lorg/gradle/testkit/runner/GradleRunner;)V
+	public static fun valueOf (Ljava/lang/String;)Lnet/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$ClasspathMode;
+	public static fun values ()[Lnet/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$ClasspathMode;
 }
 
 public final class net/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$Companion {

--- a/gradle-plugin-better-testing-junit5/api/gradle-plugin-better-testing-junit5.api
+++ b/gradle-plugin-better-testing-junit5/api/gradle-plugin-better-testing-junit5.api
@@ -34,7 +34,6 @@ public final class net/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$
 	public static final field WITH_PROJECT_CLASSPATH Lnet/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$ClasspathMode;
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public abstract fun setupRunner (Lorg/gradle/testkit/runner/GradleRunner;)V
 	public static fun valueOf (Ljava/lang/String;)Lnet/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$ClasspathMode;
 	public static fun values ()[Lnet/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration$ClasspathMode;
 }

--- a/gradle-plugin-better-testing-junit5/src/main/kotlin/net/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration.kt
+++ b/gradle-plugin-better-testing-junit5/src/main/kotlin/net/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration.kt
@@ -1,11 +1,10 @@
 package net.navatwo.gradle.testkit.junit5
 
 import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration.BuildDirectoryMode
-import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration.BuildDirectoryMode.CLEAN_BUILD
-import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration.BuildDirectoryMode.UNSET
 import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration.Companion.DEFAULT_PROJECT_ROOTS
 import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration.Companion.DEFAULT_TESTKIT_DIRECTORY
 import org.gradle.internal.impldep.org.eclipse.jgit.errors.NotSupportedException
+import org.gradle.testkit.runner.GradleRunner
 import java.io.File
 import java.lang.annotation.Inherited
 import kotlin.annotation.AnnotationRetention.RUNTIME
@@ -39,11 +38,13 @@ annotation class GradleTestKitConfiguration(
   val testKitDirectory: String = NO_OVERRIDE_VERSION,
 
   /**
-   * If true, calls [org.gradle.testkit.runner.GradleRunner.withPluginClasspath].
+   * If [ClasspathMode.WITH_PROJECT_CLASSPATH], calls
+   * [org.gradle.testkit.runner.GradleRunner.withPluginClasspath].
    *
+   * @see ClasspathMode
    * System Override: `net.navatwo.gradle.testkit.junit5.withPluginClasspath` - [SystemPropertyOverrides.SYSTEM_WITH_PLUGIN_CLASSPATH]
    */
-  val withPluginClasspath: Boolean = DEFAULT_WITH_PLUGIN_CLASSPATH,
+  val classpathMode: ClasspathMode = ClasspathMode.UNSET,
 
   /**
    * If specified, sets the gradle version via [org.gradle.testkit.runner.GradleRunner.withGradleVersion].
@@ -61,8 +62,38 @@ annotation class GradleTestKitConfiguration(
    *
    * @see BuildDirectoryMode
    */
-  val buildDirectoryMode: BuildDirectoryMode = UNSET,
+  val buildDirectoryMode: BuildDirectoryMode = BuildDirectoryMode.UNSET,
 ) {
+  enum class ClasspathMode {
+    /**
+     * Use the project classpath, i.e. call [org.gradle.testkit.runner.GradleRunner.withPluginClasspath].
+     */
+    WITH_PROJECT_CLASSPATH {
+      override fun setupRunner(runner: GradleRunner) {
+        runner.withPluginClasspath()
+      }
+    },
+
+    /**
+     * Do not add the project classpath, i.e. do not call [org.gradle.testkit.runner.GradleRunner.withPluginClasspath].
+     */
+    NO_PROJECT_CLASSPATH {
+      override fun setupRunner(runner: GradleRunner) = Unit
+    },
+
+    /**
+     * Unset value
+     */
+    UNSET {
+      override fun setupRunner(runner: GradleRunner) {
+        throw NotSupportedException("Must specify [PluginClasspathMode] specifically.")
+      }
+    }
+    ;
+
+    abstract fun setupRunner(runner: GradleRunner)
+  }
+
   enum class BuildDirectoryMode {
     /**
      * Always use a fully clean test directory by copying into a temporary directory.
@@ -107,9 +138,9 @@ annotation class GradleTestKitConfiguration(
 
     internal const val DEFAULT_TESTKIT_DIRECTORY = "build/test-kit"
 
-    internal const val DEFAULT_WITH_PLUGIN_CLASSPATH = true
+    private val DEFAULT_WITH_PLUGIN_CLASSPATH = ClasspathMode.WITH_PROJECT_CLASSPATH
 
-    internal const val DEFAULT_GRADLE_VERSION = NO_OVERRIDE_VERSION
+    private const val DEFAULT_GRADLE_VERSION = NO_OVERRIDE_VERSION
 
     internal val GradleTestKitConfiguration.effectiveGradleVersion: String?
       get() = gradleVersion.takeIf { it != NO_OVERRIDE_VERSION }
@@ -117,9 +148,9 @@ annotation class GradleTestKitConfiguration(
     internal val DEFAULT = GradleTestKitConfiguration(
       projectsRoot = DEFAULT_PROJECT_ROOTS,
       testKitDirectory = DEFAULT_TESTKIT_DIRECTORY,
-      withPluginClasspath = DEFAULT_WITH_PLUGIN_CLASSPATH,
+      classpathMode = DEFAULT_WITH_PLUGIN_CLASSPATH,
       gradleVersion = DEFAULT_GRADLE_VERSION,
-      buildDirectoryMode = CLEAN_BUILD,
+      buildDirectoryMode = BuildDirectoryMode.CLEAN_BUILD,
     )
 
     /**
@@ -143,12 +174,9 @@ annotation class GradleTestKitConfiguration(
       return GradleTestKitConfiguration(
         projectsRoot = ifNotDefault(NO_OVERRIDE_VERSION, GradleTestKitConfiguration::projectsRoot),
         testKitDirectory = ifNotDefault(NO_OVERRIDE_VERSION, GradleTestKitConfiguration::testKitDirectory),
-        withPluginClasspath = ifNotDefault(
-          default = DEFAULT_WITH_PLUGIN_CLASSPATH,
-          property = GradleTestKitConfiguration::withPluginClasspath,
-        ),
+        classpathMode = ifNotDefault(ClasspathMode.UNSET, GradleTestKitConfiguration::classpathMode),
         gradleVersion = ifNotDefault(NO_OVERRIDE_VERSION, GradleTestKitConfiguration::gradleVersion),
-        buildDirectoryMode = ifNotDefault(UNSET, GradleTestKitConfiguration::buildDirectoryMode)
+        buildDirectoryMode = ifNotDefault(BuildDirectoryMode.UNSET, GradleTestKitConfiguration::buildDirectoryMode)
       )
     }
   }

--- a/gradle-plugin-better-testing-junit5/src/main/kotlin/net/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration.kt
+++ b/gradle-plugin-better-testing-junit5/src/main/kotlin/net/navatwo/gradle/testkit/junit5/GradleTestKitConfiguration.kt
@@ -91,7 +91,7 @@ annotation class GradleTestKitConfiguration(
     }
     ;
 
-    abstract fun setupRunner(runner: GradleRunner)
+    internal abstract fun setupRunner(runner: GradleRunner)
   }
 
   enum class BuildDirectoryMode {

--- a/gradle-plugin-better-testing-junit5/src/test/kotlin/net/navatwo/gradle/testkit/junit5/GradleTestKitConfigurationTest.kt
+++ b/gradle-plugin-better-testing-junit5/src/test/kotlin/net/navatwo/gradle/testkit/junit5/GradleTestKitConfigurationTest.kt
@@ -1,5 +1,6 @@
 package net.navatwo.gradle.testkit.junit5
 
+import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration.ClasspathMode.NO_PROJECT_CLASSPATH
 import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration.Companion.merge
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -17,14 +18,14 @@ internal class GradleTestKitConfigurationTest {
       projectsRoot = "class",
       testKitDirectory = "class",
       gradleVersion = "class",
-      withPluginClasspath = false,
+      classpathMode = NO_PROJECT_CLASSPATH,
     )
 
     assertThat(merge(methodAnn, classAnn)).isEqualTo(
       GradleTestKitConfiguration(
         projectsRoot = methodAnn.projectsRoot,
         testKitDirectory = classAnn.testKitDirectory,
-        withPluginClasspath = classAnn.withPluginClasspath,
+        classpathMode = classAnn.classpathMode,
         gradleVersion = methodAnn.gradleVersion,
       )
     )

--- a/gradle-plugin-better-testing-junit5/src/test/kotlin/net/navatwo/gradle/testkit/junit5/integration_test/ExtensionTests.kt
+++ b/gradle-plugin-better-testing-junit5/src/test/kotlin/net/navatwo/gradle/testkit/junit5/integration_test/ExtensionTests.kt
@@ -3,6 +3,8 @@ package net.navatwo.gradle.testkit.junit5.integration_test
 import net.navatwo.gradle.testkit.assertj.task
 import net.navatwo.gradle.testkit.junit5.GradleProject
 import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration
+import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration.ClasspathMode.NO_PROJECT_CLASSPATH
+import net.navatwo.gradle.testkit.junit5.GradleTestKitConfiguration.ClasspathMode.WITH_PROJECT_CLASSPATH
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test
@@ -64,5 +66,23 @@ class ExtensionTests {
     assertThat(gradleRunner1)
       .isSameAs(gradleRunner2)
       .isSameAs(gradleRunner3)
+  }
+
+  @Test
+  @GradleProject(projectDir = "default-project-root")
+  @GradleTestKitConfiguration(classpathMode = WITH_PROJECT_CLASSPATH)
+  fun `withPluginClasspath is applied when overriding to WITH_PROJECT_CLASSPATH`(
+    config: GradleTestKitConfiguration,
+  ) {
+    assertThat(config.classpathMode).isEqualTo(WITH_PROJECT_CLASSPATH)
+  }
+
+  @Test
+  @GradleProject(projectDir = "default-project-root")
+  @GradleTestKitConfiguration(classpathMode = NO_PROJECT_CLASSPATH)
+  fun `withPluginClasspath overridden to NO_PROJECT_CLASSPATH causes classpath to be empty`(
+    config: GradleTestKitConfiguration,
+  ) {
+    assertThat(config.classpathMode).isEqualTo(NO_PROJECT_CLASSPATH)
   }
 }


### PR DESCRIPTION
This adds a new enum for classpath behaviour that can be configured. In #25, we accidentally caused the `withPluginClasspath` value to improperly fallback to `false` which breaks a _lot_ of tests in practice. Further, we had no test coverage for this.

Closes #27.